### PR TITLE
fix(github): update download and upload artifact actions to v4

### DIFF
--- a/.github/actions/checkout/action.yaml
+++ b/.github/actions/checkout/action.yaml
@@ -39,7 +39,7 @@ runs:
       id: download-bundle
       if: ${{ startsWith(github.event_name, 'pull_request') || inputs.modality != 'NORMAL' }}
       continue-on-error: true
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: hopic-merge-transfer.bundle
 
@@ -140,7 +140,7 @@ runs:
 
     - name: Upload Merge Transfer Git Bundle
       if: ${{ steps.download-bundle.outcome != 'success' && (startsWith(github.event_name, 'pull_request') || (inputs.modality && inputs.modality != 'NORMAL')) }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: hopic-merge-transfer.bundle
         path: hopic-merge-transfer.bundle

--- a/.github/actions/submit/action.yaml
+++ b/.github/actions/submit/action.yaml
@@ -18,7 +18,7 @@ runs:
       if: ${{ !startsWith(github.event_name, 'pull_request') || contains(github.event.pull_request.labels.*.name, 'automerge') }}
       id: download-bundle
       continue-on-error: true
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: hopic-merge-transfer.bundle
 


### PR DESCRIPTION
See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/